### PR TITLE
🩹 Add crossOrigin to link

### DIFF
--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "~/components/Icon/Icon";
 import iconStyles from "~/components/Icon/icon.css";
 import { LinksFunction, LoaderFunction, useLoaderData } from "remix";
+import { LinkDescriptor } from "@remix-run/server-runtime/dist/links";
 
 type SiteMetadata = {
   name: string;
@@ -38,31 +39,13 @@ export const loader: LoaderFunction = (): SiteMetadata => {
   };
 };
 
+const createSVGLink = (href: string):LinkDescriptor => ({ href, rel: "preload", as: "image", type: "image/svg+xml", crossOrigin: "anonymous" })
+
 export const links: LinksFunction = () => [
-  {
-    rel: "preload",
-    href: "/icons/email.svg",
-    as: "image",
-    type: "image/svg+xml",
-  },
-  {
-    rel: "preload",
-    href: "/icons/github.svg",
-    as: "image",
-    type: "image/svg+xml",
-  },
-  {
-    rel: "preload",
-    href: "/icons/location.svg",
-    as: "image",
-    type: "image/svg+xml",
-  },
-  {
-    rel: "preload",
-    href: "/icons/twitter.svg",
-    as: "image",
-    type: "image/svg+xml",
-  },
+  createSVGLink("/icons/email.svg"),
+  createSVGLink("/icons/github.svg"),
+  createSVGLink("/icons/location.svg"),
+  createSVGLink("/icons/twitter.svg"),
   { rel: "stylesheet", href: iconStyles },
 ];
 


### PR DESCRIPTION
There was a warning in the browser console that reads

> "A preload for 'https://themattcode.com/icons/location.svg' is found,
>    but is not used because the request credentials mode does not match.
>    Consider taking a look at crossorigin attribute."

This was fixed with the suggested additional attribute in the <link>.